### PR TITLE
Fix: Preserve actual start value in chunk download to ensure correct chunk order

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,17 +90,18 @@ async function fetchInChunks(url, options = {}) {
   ) {
     let chunks = [];
     let queue = [];
-    let start = 0;
     let downloadedBytes = 0;
 
     // Function to process the queue
     async function processQueue() {
+      let start = 0;
       while (start < fileSize) {
         if (queue.length < maxParallelRequests) {
           let end = Math.min(start + chunkSize - 1, fileSize - 1);
+          let actualStart = start; // Preserve the actual start value
           let promise = fetchChunk(url, start, end, signal)
             .then((chunk) => {
-              chunks.push({ start, chunk });
+              chunks.push({ start: actualStart, chunk }); // Use preserved start value
               downloadedBytes += chunk.byteLength;
 
               if (progressCallback) {


### PR DESCRIPTION
The logical error in the old code is related to the handling of the `start` value when fetching chunks. Specifically, the `start` value is not preserved correctly when pushing chunks to the `chunks` array. This can lead to issues with chunk ordering during parallel downloads.

### Old Code Issue:
In the `downloadChunks` function, the `start` value is used to fetch a chunk, but it is not preserved when the chunk is pushed to the `chunks` array. This can cause the chunks to be out of order because the `start` value is incremented before the chunk is fetched and pushed to the array.

### Fix:
To fix this, the `start` value should be preserved in a variable (`actualStart`) before it is incremented. This preserved value should then be used when pushing the chunk to the `chunks` array.

### Pseudocode:
1. Define a variable `actualStart` to preserve the `start` value.
2. Use `actualStart` when pushing the chunk to the `chunks` array.
